### PR TITLE
WIP: Bug rvalue copy

### DIFF
--- a/source/tests/yats-test/taskconfigurator_test.cpp
+++ b/source/tests/yats-test/taskconfigurator_test.cpp
@@ -19,6 +19,22 @@ TEST(taskconfigurator_test, return_parameters)
     EXPECT_NO_THROW(configurator.output<0>());
 }
 
+TEST(taskconfigurator_test, return_one_element_not_in_tuple)
+{
+    struct Task
+    {
+        yats::slot<int, 71> run(yats::slot<int, 14> input)
+        {
+            return input + 1;
+        }
+    };
+
+    yats::task_configurator<Task> configurator;
+
+    EXPECT_NO_THROW(configurator.input<14>());
+    EXPECT_NO_THROW(configurator.output<71>());
+}
+
 TEST(taskconfigurator_test, multiple_returns_multiple_parameters)
 {
     struct Task

--- a/source/tests/yats-test/util_test.cpp
+++ b/source/tests/yats-test/util_test.cpp
@@ -24,21 +24,45 @@ TEST(util_test, is_unique_ptr_test)
 
 TEST(util_test, is_shared_ptr_test)
 {
-    EXPECT_TRUE(yats::is_shared_ptr_v<std::shared_ptr<int>>);
-    EXPECT_FALSE(yats::is_shared_ptr_v<std::unique_ptr<int>>);
-    EXPECT_FALSE(yats::is_shared_ptr_v<int>);
-    EXPECT_FALSE(yats::is_shared_ptr_v<int*>);
-    EXPECT_FALSE(yats::is_shared_ptr_v<int&>);
-    EXPECT_FALSE(yats::is_shared_ptr_v<const int&>);
-    EXPECT_FALSE(yats::is_shared_ptr_v<void>);
+	EXPECT_TRUE(yats::is_shared_ptr_v<std::shared_ptr<int>>);
+	EXPECT_FALSE(yats::is_shared_ptr_v<std::unique_ptr<int>>);
+	EXPECT_FALSE(yats::is_shared_ptr_v<int>);
+	EXPECT_FALSE(yats::is_shared_ptr_v<int*>);
+	EXPECT_FALSE(yats::is_shared_ptr_v<int&>);
+	EXPECT_FALSE(yats::is_shared_ptr_v<const int&>);
+	EXPECT_FALSE(yats::is_shared_ptr_v<void>);
 
-    struct no_shared_ptr
-    {
-        char dummy;
-    };
+	struct no_shared_ptr
+	{
+		char dummy;
+	};
 
-    EXPECT_FALSE(yats::is_unique_ptr_v<no_shared_ptr>);
-    EXPECT_FALSE(yats::is_unique_ptr_v<no_shared_ptr*>);
+	EXPECT_FALSE(yats::is_unique_ptr_v<no_shared_ptr>);
+	EXPECT_FALSE(yats::is_unique_ptr_v<no_shared_ptr*>);
+}
+
+TEST(util_test, is_tuple_test)
+{
+	EXPECT_TRUE(yats::is_tuple_v<std::tuple<>>);
+	EXPECT_TRUE(yats::is_tuple_v<std::tuple<int>>);
+	auto val = yats::is_tuple_v<std::tuple<int, float>>;
+	EXPECT_TRUE(val);
+
+	EXPECT_FALSE(yats::is_tuple_v<std::shared_ptr<int>>);
+	EXPECT_FALSE(yats::is_tuple_v<std::unique_ptr<int>>);
+	EXPECT_FALSE(yats::is_tuple_v<int>);
+	EXPECT_FALSE(yats::is_tuple_v<int*>);
+	EXPECT_FALSE(yats::is_tuple_v<int&>);
+	EXPECT_FALSE(yats::is_tuple_v<const int&>);
+	EXPECT_FALSE(yats::is_tuple_v<void>);
+
+	struct no_shared_ptr
+	{
+		char dummy;
+	};
+
+	EXPECT_FALSE(yats::is_tuple_v<no_shared_ptr>);
+	EXPECT_FALSE(yats::is_tuple_v<no_shared_ptr*>);
 }
 
 TEST(util_test, has_run_test)

--- a/source/tests/yats-test/util_test.cpp
+++ b/source/tests/yats-test/util_test.cpp
@@ -24,45 +24,45 @@ TEST(util_test, is_unique_ptr_test)
 
 TEST(util_test, is_shared_ptr_test)
 {
-	EXPECT_TRUE(yats::is_shared_ptr_v<std::shared_ptr<int>>);
-	EXPECT_FALSE(yats::is_shared_ptr_v<std::unique_ptr<int>>);
-	EXPECT_FALSE(yats::is_shared_ptr_v<int>);
-	EXPECT_FALSE(yats::is_shared_ptr_v<int*>);
-	EXPECT_FALSE(yats::is_shared_ptr_v<int&>);
-	EXPECT_FALSE(yats::is_shared_ptr_v<const int&>);
-	EXPECT_FALSE(yats::is_shared_ptr_v<void>);
+    EXPECT_TRUE(yats::is_shared_ptr_v<std::shared_ptr<int>>);
+    EXPECT_FALSE(yats::is_shared_ptr_v<std::unique_ptr<int>>);
+    EXPECT_FALSE(yats::is_shared_ptr_v<int>);
+    EXPECT_FALSE(yats::is_shared_ptr_v<int*>);
+    EXPECT_FALSE(yats::is_shared_ptr_v<int&>);
+    EXPECT_FALSE(yats::is_shared_ptr_v<const int&>);
+    EXPECT_FALSE(yats::is_shared_ptr_v<void>);
 
-	struct no_shared_ptr
-	{
-		char dummy;
-	};
+    struct no_shared_ptr
+    {
+        char dummy;
+    };
 
-	EXPECT_FALSE(yats::is_unique_ptr_v<no_shared_ptr>);
-	EXPECT_FALSE(yats::is_unique_ptr_v<no_shared_ptr*>);
+    EXPECT_FALSE(yats::is_unique_ptr_v<no_shared_ptr>);
+    EXPECT_FALSE(yats::is_unique_ptr_v<no_shared_ptr*>);
 }
 
 TEST(util_test, is_tuple_test)
 {
-	EXPECT_TRUE(yats::is_tuple_v<std::tuple<>>);
-	EXPECT_TRUE(yats::is_tuple_v<std::tuple<int>>);
-	auto val = yats::is_tuple_v<std::tuple<int, float>>;
-	EXPECT_TRUE(val);
+    EXPECT_TRUE(yats::is_tuple_v<std::tuple<>>);
+    EXPECT_TRUE(yats::is_tuple_v<std::tuple<int>>);
+    auto val = yats::is_tuple_v<std::tuple<int, float>>;
+    EXPECT_TRUE(val);
 
-	EXPECT_FALSE(yats::is_tuple_v<std::shared_ptr<int>>);
-	EXPECT_FALSE(yats::is_tuple_v<std::unique_ptr<int>>);
-	EXPECT_FALSE(yats::is_tuple_v<int>);
-	EXPECT_FALSE(yats::is_tuple_v<int*>);
-	EXPECT_FALSE(yats::is_tuple_v<int&>);
-	EXPECT_FALSE(yats::is_tuple_v<const int&>);
-	EXPECT_FALSE(yats::is_tuple_v<void>);
+    EXPECT_FALSE(yats::is_tuple_v<std::shared_ptr<int>>);
+    EXPECT_FALSE(yats::is_tuple_v<std::unique_ptr<int>>);
+    EXPECT_FALSE(yats::is_tuple_v<int>);
+    EXPECT_FALSE(yats::is_tuple_v<int*>);
+    EXPECT_FALSE(yats::is_tuple_v<int&>);
+    EXPECT_FALSE(yats::is_tuple_v<const int&>);
+    EXPECT_FALSE(yats::is_tuple_v<void>);
 
-	struct no_shared_ptr
-	{
-		char dummy;
-	};
+    struct no_shared_ptr
+    {
+        char dummy;
+    };
 
-	EXPECT_FALSE(yats::is_tuple_v<no_shared_ptr>);
-	EXPECT_FALSE(yats::is_tuple_v<no_shared_ptr*>);
+    EXPECT_FALSE(yats::is_tuple_v<no_shared_ptr>);
+    EXPECT_FALSE(yats::is_tuple_v<no_shared_ptr*>);
 }
 
 TEST(util_test, has_run_test)

--- a/source/yats/include/yats/task_container.h
+++ b/source/yats/include/yats/task_container.h
@@ -47,9 +47,16 @@ public:
 
 protected:
     template <size_t... index, typename T = typename helper::output_type>
-    std::enable_if_t<!std::is_same<T, void>::value> invoke(std::integer_sequence<size_t, index...>)
+    std::enable_if_t<!std::is_same<T, void>::value && is_tuple_v<T>> invoke(std::integer_sequence<size_t, index...>)
     {
         auto output = m_task.run(get<index>()...);
+        write(output);
+    }
+
+    template <size_t... index, typename T = typename helper::output_type>
+    std::enable_if_t<!std::is_same<T, void>::value && !is_tuple_v<T>> invoke(std::integer_sequence<size_t, index...>)
+    {
+        auto output = std::make_tuple(m_task.run(get<index>()...));
         write(output);
     }
 

--- a/source/yats/include/yats/task_helper.h
+++ b/source/yats/include/yats/task_helper.h
@@ -36,21 +36,21 @@ struct output_wrapper<std::tuple<ParameterTypes...>>
 template <typename T, uint64_t Id>
 struct output_wrapper<slot<T, Id>>
 {
-	using callbacks = std::tuple<std::vector<std::function<void(T)>>>;
-	using connectors = std::tuple<output_connector<T>>;
-	using tuple = std::tuple<slot<T, Id>>;
+    using callbacks = std::tuple<std::vector<std::function<void(T)>>>;
+    using connectors = std::tuple<output_connector<T>>;
+    using tuple = std::tuple<slot<T, Id>>;
 
-	static constexpr size_t parameter_count = 1;
+    static constexpr size_t parameter_count = 1;
 };
 
 template <>
 struct output_wrapper<void>
 {
-	using callbacks = std::tuple<>;
-	using connectors = std::tuple<>;
-	using tuple = std::tuple<>;
+    using callbacks = std::tuple<>;
+    using connectors = std::tuple<>;
+    using tuple = std::tuple<>;
 
-	static constexpr size_t parameter_count = 0;
+    static constexpr size_t parameter_count = 0;
 };
 
 template <typename Return, typename... ParameterTypes>

--- a/source/yats/include/yats/task_helper.h
+++ b/source/yats/include/yats/task_helper.h
@@ -5,10 +5,14 @@
 #include <queue>
 #include <vector>
 
-#include <yats/output_connector.h>
-
 namespace yats
 {
+
+template <typename T>
+class output_connector;
+
+template <typename T, uint64_t Id>
+class slot;
 
 template <typename T>
 struct output_wrapper;
@@ -29,14 +33,24 @@ struct output_wrapper<std::tuple<ParameterTypes...>>
     static constexpr size_t parameter_count = sizeof...(ParameterTypes);
 };
 
+template <typename T, uint64_t Id>
+struct output_wrapper<slot<T, Id>>
+{
+	using callbacks = std::tuple<std::vector<std::function<void(T)>>>;
+	using connectors = std::tuple<output_connector<T>>;
+	using tuple = std::tuple<slot<T, Id>>;
+
+	static constexpr size_t parameter_count = 1;
+};
+
 template <>
 struct output_wrapper<void>
 {
-    using callbacks = std::tuple<>;
-    using connectors = std::tuple<>;
-    using tuple = std::tuple<>;
+	using callbacks = std::tuple<>;
+	using connectors = std::tuple<>;
+	using tuple = std::tuple<>;
 
-    static constexpr size_t parameter_count = 0;
+	static constexpr size_t parameter_count = 0;
 };
 
 template <typename Return, typename... ParameterTypes>
@@ -57,16 +71,16 @@ struct task_helper
     using output_type = Return;
 
     using input_tuple = std::tuple<ParameterTypes...>;
-    using output_tuple = typename output_wrapper<output_type>::tuple;
+    using output_tuple = typename output_wrapper<Return>::tuple;
 
     using input_callbacks = std::tuple<decltype(transform_callback<ParameterTypes>())...>;
-    using output_callbacks = typename output_wrapper<output_type>::callbacks;
+    using output_callbacks = typename output_wrapper<Return>::callbacks;
 
     using input_connectors = std::tuple<decltype(transform_connector<ParameterTypes>())...>;
-    using output_connectors = typename output_wrapper<output_type>::connectors;
+    using output_connectors = typename output_wrapper<Return>::connectors;
 
     static constexpr size_t input_count = sizeof...(ParameterTypes);
-    static constexpr size_t output_count = output_wrapper<output_type>::parameter_count;
+    static constexpr size_t output_count = output_wrapper<Return>::parameter_count;
 };
 
 template <typename ReturnType, typename TaskType, typename... ParameterTypes>

--- a/source/yats/include/yats/util.h
+++ b/source/yats/include/yats/util.h
@@ -54,6 +54,24 @@ struct is_shared_ptr<void>
 template <typename T>
 constexpr bool is_shared_ptr_v = is_shared_ptr<T>::value;
 
+template <typename T>
+struct is_tuple
+{
+    template <typename... U>
+    static char test_function(const std::tuple<U...>&);
+    static int test_function(...);
+    static constexpr bool value = sizeof(test_function(std::declval<T>())) == sizeof(char);
+};
+
+template <>
+struct is_tuple<void>
+{
+    static constexpr bool value = false;
+};
+
+template <typename T>
+constexpr bool is_tuple_v = is_tuple<T>::value;
+
 template <uint64_t Id, typename T>
 struct get_index_by_id
 {


### PR DESCRIPTION
Line 84 should copy one value, but copies both values. rvalues given into the pipeline should never be copied.