### PR TITLE
Fix custom constructor

### DIFF
--- a/source/tests/yats-test/custom_constructor_test.cpp
+++ b/source/tests/yats-test/custom_constructor_test.cpp
@@ -42,8 +42,8 @@ TEST(custom_constructor_test, reference_as_argument)
     int end_value = -1;
 
     yats::pipeline pipeline;
-    auto source = pipeline.add<Source>(start_value);
-    auto target = pipeline.add<Target>(end_value);
+    auto source = pipeline.add<Source>(std::cref(start_value));
+    auto target = pipeline.add<Target>(std::ref(end_value));
 
     source->output<0>() >> target->input<0>();
     
@@ -54,6 +54,39 @@ TEST(custom_constructor_test, reference_as_argument)
     scheduler.run();
     EXPECT_EQ(start_value, end_value);
 }
+
+TEST(custom_constructor_test, no_reference_as_argument)
+{
+    struct Task
+    {
+        Task(uint8_t no_reference, uint8_t& reference)
+            : m_no_reference(no_reference)
+            , m_reference(reference)
+        {
+        }
+
+        void run()
+        {
+            m_reference = m_no_reference;
+        }
+
+        uint8_t m_no_reference;
+        uint8_t& m_reference;
+    };
+
+    yats::pipeline pipeline;
+
+    uint8_t output_value = 10;
+    uint8_t input_value = 0;
+    pipeline.add<Task>(input_value, std::ref(output_value));
+    input_value += 5;
+
+    yats::scheduler scheduler(pipeline);
+    scheduler.run();
+
+    EXPECT_EQ(output_value, 0);
+}
+
 
 struct constructor_counter
 {
@@ -96,7 +129,7 @@ TEST(custom_constructor_test, no_unnecessary_copy)
     yats::pipeline pipeline;
 
     uint8_t copy_counter = 0;
-    pipeline.add<Task>(copy_counter, constructor_counter());
+    pipeline.add<Task>(std::ref(copy_counter), constructor_counter());
 
     // This should be the only place, where the copy constructor is called
     // Also it should be called only once

--- a/source/tests/yats-test/custom_constructor_test.cpp
+++ b/source/tests/yats-test/custom_constructor_test.cpp
@@ -54,3 +54,54 @@ TEST(custom_constructor_test, reference_as_argument)
     scheduler.run();
     EXPECT_EQ(start_value, end_value);
 }
+
+struct constructor_counter
+{
+    constructor_counter() = default;
+    constructor_counter(const constructor_counter& rhs)
+    {
+        copied = rhs.copied + 1;
+        moved = rhs.moved;
+    }
+
+    constructor_counter(constructor_counter&& rhs)
+    {
+        copied = rhs.copied;
+        moved = rhs.moved + 1;
+    }
+
+    uint8_t copied = 0;
+    uint8_t moved = 0;
+};
+
+TEST(custom_constructor_test, no_unnecessary_copy)
+{
+    struct Task
+    {
+        Task(uint8_t& c, constructor_counter cc)
+            : copied(c)
+            , counter(std::move(cc))
+        {
+        }
+
+        void run()
+        {
+            copied = counter.copied;
+        }
+
+        uint8_t& copied;
+        constructor_counter counter;
+    };
+
+    yats::pipeline pipeline;
+
+    uint8_t copy_counter = 0;
+    pipeline.add<Task>(copy_counter, constructor_counter());
+
+    // This should be the only place, where the copy constructor is called
+    // Also it should be called only once
+    yats::scheduler scheduler(pipeline);
+    scheduler.run();
+
+    EXPECT_EQ(copy_counter, 1);
+}

--- a/source/tests/yats-test/custom_constructor_test.cpp
+++ b/source/tests/yats-test/custom_constructor_test.cpp
@@ -1,8 +1,7 @@
 #include <gmock/gmock.h>
 
-#include <yats/slot.h>
-#include <yats/pipeline.h>
 #include <yats/scheduler.h>
+#include <yats/slot.h>
 
 TEST(custom_constructor_test, reference_as_argument)
 {

--- a/source/yats/include/yats/connection_helper.h
+++ b/source/yats/include/yats/connection_helper.h
@@ -6,6 +6,7 @@
 
 #include <yats/input_connector.h>
 #include <yats/output_connector.h>
+#include <yats/task_helper.h>
 
 namespace yats
 {

--- a/source/yats/include/yats/task_configurator.h
+++ b/source/yats/include/yats/task_configurator.h
@@ -30,7 +30,7 @@ public:
     using helper = decltype(make_helper(&Task::run));
 
     task_configurator(Parameters&&... parameters)
-        : m_construction_parameters(std::forward_as_tuple(std::forward<Parameters>(parameters)...))
+        : m_construction_parameters(std::forward<Parameters>(parameters)...)
     {
     }
     
@@ -52,7 +52,7 @@ public:
 
     std::unique_ptr<abstract_task_container> construct_task_container(std::unique_ptr<abstract_connection_helper> helper) const override
     {
-        return std::make_unique<task_container<Task, Parameters...>>(static_cast<connection_helper<Task>*>(helper.get()), m_construction_parameters);
+        return std::make_unique<task_container<Task, std::remove_reference_t<Parameters>...>>(static_cast<connection_helper<Task>*>(helper.get()), m_construction_parameters);
     }
 
     std::unique_ptr<abstract_connection_helper> construct_connection_helper() const override
@@ -91,6 +91,6 @@ protected:
 
     typename helper::input_connectors m_inputs;
     typename helper::output_connectors m_outputs;
-    const std::tuple<Parameters...> m_construction_parameters;
+    const std::tuple<std::remove_reference_t<Parameters>...> m_construction_parameters;
 };
 }

--- a/source/yats/include/yats/task_configurator.h
+++ b/source/yats/include/yats/task_configurator.h
@@ -30,7 +30,7 @@ public:
     using helper = decltype(make_helper(&Task::run));
 
     task_configurator(Parameters&&... parameters)
-        : m_construction_parameters(std::forward_as_tuple(parameters...))
+        : m_construction_parameters(std::forward_as_tuple(std::forward<Parameters>(parameters)...))
     {
     }
     

--- a/source/yats/include/yats/task_container.h
+++ b/source/yats/include/yats/task_container.h
@@ -45,7 +45,7 @@ public:
         : abstract_task_container(connection->following_nodes())
         , m_input(connection->queue())
         , m_output(connection->callbacks())
-        , m_task(make_from_tuple<Task>(std::tuple<Parameters...>(parameter_tuple)))
+        , m_task(make_from_tuple<Task>(std::tuple<Parameters...>(std::move(parameter_tuple))))
     {
     }
 

--- a/source/yats/include/yats/task_container.h
+++ b/source/yats/include/yats/task_container.h
@@ -45,7 +45,7 @@ public:
         : abstract_task_container(connection->following_nodes())
         , m_input(connection->queue())
         , m_output(connection->callbacks())
-        , m_task(make_from_tuple<Task>(std::tuple<Parameters...>(std::move(parameter_tuple))))
+        , m_task(make_from_tuple<Task>(std::move(parameter_tuple)))
     {
     }
 


### PR DESCRIPTION
See #92 
Closes #93 

Fixes two things:
1. rvalues do not get copied unnecessarily anymore
2. We do not take references in pipelines add function anymore. It was standard behaviour to construct a task with a lvalue even though the task itself expected a rvalue, which made it possible to work with variables which already went out of scope -> undefined behavior. If the user wants to supply a reference he has to use std::reference_wrapper<>.