### PR TITLE
Check move- / copyconstructibility

### DIFF
--- a/source/tests/compilation/CMakeLists.txt
+++ b/source/tests/compilation/CMakeLists.txt
@@ -36,3 +36,4 @@ set_target_properties(compilation_test PROPERTIES FOLDER "Tests/Compilation")
 
 add_compilation_test(demo)
 add_compilation_test(type_safe_connection)
+add_compilation_test(slot_move_constructible)

--- a/source/tests/compilation/CMakeLists.txt
+++ b/source/tests/compilation/CMakeLists.txt
@@ -35,5 +35,5 @@ set_target_properties(compilation_test PROPERTIES FOLDER "Tests/Compilation")
 #
 
 add_compilation_test(demo)
-add_compilation_test(type_safe_connection)
 add_compilation_test(slot_move_constructible)
+add_compilation_test(type_safe_connection)

--- a/source/tests/compilation/slot_move_constructible.cpp
+++ b/source/tests/compilation/slot_move_constructible.cpp
@@ -1,0 +1,19 @@
+#include <yats/slot.h>
+
+struct test
+{
+    test() = default;
+    test(const test&) = default;
+#ifdef SHOULD_FAIL
+    test(test&&) = delete;
+#else
+    test(test&&) = default;
+#endif
+};
+
+int main()
+{
+    test t;
+    yats::slot<test, 0> slot(t);
+    return 0;
+}

--- a/source/tests/yats-test/scheduler_test.cpp
+++ b/source/tests/yats-test/scheduler_test.cpp
@@ -28,3 +28,14 @@ TEST(scheduler_test, multithreaded_timing_test)
     EXPECT_GE(duration, 100);
     EXPECT_LE(duration, 500);
 }
+
+TEST(scheduler_test, throw_on_creation)
+{
+    yats::pipeline pipeline;
+
+    auto source = pipeline.add([]() -> yats::slot<std::unique_ptr<int>, 0> { return std::make_unique<int>(0); });
+    source->add_listener<0>([](std::unique_ptr<int>) {});
+    source->add_listener<0>([](std::unique_ptr<int>) {});
+
+    EXPECT_THROW(yats::scheduler scheduler(pipeline), std::runtime_error);
+}

--- a/source/yats/include/yats/slot.h
+++ b/source/yats/include/yats/slot.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <tuple>
+#include <type_traits>
+
 namespace yats
 {
 
@@ -18,6 +22,8 @@ class slot
 public:
     using value_type = T;
     static constexpr uint64_t id = Id;
+
+    static_assert(std::is_move_constructible_v<value_type>, "The slots value type must be move constructible.");
 
     /// <summary>Creates a new slot object.</summary>
     /// <param name = "value">Initial value of slot</param>

--- a/source/yats/include/yats/slot.h
+++ b/source/yats/include/yats/slot.h
@@ -23,7 +23,7 @@ public:
     using value_type = T;
     static constexpr uint64_t id = Id;
 
-    static_assert(std::is_move_constructible_v<value_type>, "The slots value type must be move constructible.");
+    static_assert(std::is_move_constructible<value_type>::value, "The slots value type has to be move constructible.");
 
     /// <summary>Creates a new slot object.</summary>
     /// <param name = "value">Initial value of slot</param>

--- a/source/yats/include/yats/task_container.h
+++ b/source/yats/include/yats/task_container.h
@@ -157,7 +157,7 @@ protected:
     template <size_t Index>
     bool check_copyable_impl() const
     {
-        return std::is_copy_constructible_v<std::tuple_element_t<Index, typename helper::output_tuple>> || std::get<Index>(m_output).size() < 2;
+        return std::is_copy_constructible<std::tuple_element_t<Index, typename helper::output_tuple>>::value || std::get<Index>(m_output).size() < 2;
     }
 
     typename helper::input_queue_ptr m_input;


### PR DESCRIPTION
Adds checks if the underlying types of a slot are move-/copyconstructrible earlier in the workflow.
Closes #106 
Closes #113 