### PR TITLE
pipeline.build() consumes some variables so it is only valid to call …

### DIFF
--- a/source/yats/include/yats/pipeline.h
+++ b/source/yats/include/yats/pipeline.h
@@ -40,7 +40,7 @@ public:
         return static_cast<task_configurator<Task, Parameters...>*>(m_tasks.back().get());
     }
 
-    std::vector<std::unique_ptr<abstract_task_container>> build() const
+    std::vector<std::unique_ptr<abstract_task_container>> build() const &&
     {
         std::vector<std::unique_ptr<abstract_connection_helper>> helpers;
         for (const auto& configurator : m_tasks)

--- a/source/yats/include/yats/scheduler.h
+++ b/source/yats/include/yats/scheduler.h
@@ -16,7 +16,7 @@ namespace yats
 class scheduler
 {
 public:
-    explicit scheduler(pipeline&& pipeline)
+    explicit scheduler(pipeline pipeline)
         : m_tasks(std::move(pipeline).build())
     {
     }

--- a/source/yats/include/yats/scheduler.h
+++ b/source/yats/include/yats/scheduler.h
@@ -16,8 +16,8 @@ namespace yats
 class scheduler
 {
 public:
-    explicit scheduler(pipeline pipeline)
-        : m_tasks(pipeline.build())
+    explicit scheduler(pipeline&& pipeline)
+        : m_tasks(std::move(pipeline).build())
     {
     }
 


### PR DESCRIPTION
…this on anrvalue that will never be used again.