### PR TITLE
Add anonymous constraints.

### DIFF
--- a/source/tests/yats-test/scheduler_test.cpp
+++ b/source/tests/yats-test/scheduler_test.cpp
@@ -133,8 +133,8 @@ TEST(scheduler_test, various_constraints_run)
     auto main_task_config = pipeline.add<task>();
     auto other_task_config = pipeline.add<task>();
 
-    main_task_config->add_thread_constraint(thread_group::main_thread());
-    other_task_config->add_thread_constraint(thread_group("other"));
+    main_task_config->set_thread_constraint(thread_group::main_thread());
+    other_task_config->set_thread_constraint(thread_group("other"));
 
     int any_value = 0;
     int main_value = 0;

--- a/source/tests/yats-test/task_configurator_test.cpp
+++ b/source/tests/yats-test/task_configurator_test.cpp
@@ -97,7 +97,8 @@ TEST(task_configurator_test, thread_constraints_default)
     task_configurator<Task> configurator;
     auto constraints = configurator.thread_constraints();
 
-    EXPECT_EQ(constraints.names().count(thread_group::name_for(thread_group::ANY)), 1);
+    EXPECT_EQ(constraints.names().count(thread_group::name_for(thread_group::ANY)), 0);
+    EXPECT_EQ(constraints.names().count(thread_group::name_for(thread_group::MAIN)), 0);
     EXPECT_EQ(constraints.names().size(), 1);
 }
 

--- a/source/yats/include/yats/constraint.h
+++ b/source/yats/include/yats/constraint.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -12,7 +13,7 @@ class thread_group_helper;
 class thread_group
 {
 public:
-    explicit thread_group(const std::string& name = name_for(ANY))
+    explicit thread_group(const std::string& name = anonymous_thread())
         : m_names{ name }
     {
     }
@@ -76,6 +77,14 @@ public:
     }
 
 protected:
+    static std::string anonymous_thread()
+    {
+        static std::atomic<uint64_t> id;
+        static const std::string anonymous_thread_prefix("__yats_anonymous_thread_");
+
+        return anonymous_thread_prefix + std::to_string(id.fetch_add(1));
+    }
+
     std::set<std::string> m_names;
 };
 

--- a/source/yats/include/yats/task_configurator.h
+++ b/source/yats/include/yats/task_configurator.h
@@ -36,9 +36,9 @@ public:
         return m_externals.find(connector) != m_externals.cend();
     }
 
-    void add_thread_constraint(const thread_group& group)
+    void set_thread_constraint(const thread_group& group)
     {
-        m_thread_constraint |= group;
+        m_thread_constraint = group;
     }
 
     const thread_group& thread_constraints() const


### PR DESCRIPTION
This fixes the multithreading feature bug and always grantees the parameter order except when any thread is used (which is not the default anymore).